### PR TITLE
Make the multiple-field_type visible and aligned correctly

### DIFF
--- a/resources/less/flat-ui/modules/forms.less
+++ b/resources/less/flat-ui/modules/forms.less
@@ -76,7 +76,7 @@ label {
   font-family: @font-family-base;
   font-size: @input-font-size-base;
   line-height: @input-line-height-base;
-  padding: 8px 12px;
+  padding: 6px 12px;
   height: 42px;
   border-radius: @input-border-radius;
   box-shadow: none;

--- a/resources/less/flat-ui/modules/select.less
+++ b/resources/less/flat-ui/modules/select.less
@@ -216,6 +216,7 @@
   height: 27px;
   padding: 6px 21px;
   transition: .25s linear;
+  background-color: @gray;
 
   &:hover {
     padding-right: 28px;


### PR DESCRIPTION
It looks like there is too much padding at the front of the tags, but I didn't want to change it since every other input element has the same padding.
